### PR TITLE
[MINOR] Update README footer imagelink

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,5 +79,5 @@ mtcars <- import_table("test/mtcars.csv", FUN = readr::read_csv)
 <br/><br/>
 
 
-<img src="http://i65.tinypic.com/9h4ajs.png" align="centre" />
+<img src="https://user-images.githubusercontent.com/408863/66741678-a78ab780-ee93-11e9-8d90-b274af222339.png" align="centre" />
 


### PR DESCRIPTION
- Use footer image on Github itself instead of a third party service
- Got the original image from Wayback Archive (https://web.archive.org/web/*/https://github.com/atlanhq/camelot)